### PR TITLE
Broadcast events when accounts are linked or unlinked

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ DISCORD_CLIENT_SECRET=your-discord-secret
 REDIS_URL=redis://127.0.0.1:3579
 
 # The application portal integrations instance to connect to
-APPLICATION_PORTAL_URL=http://integrations.application-portal.wafflemaker.internal:8000
+APPLICATION_PORTAL_URL=http://127.0.0.1:3580
 
 # OpenTelemetry exporter configuration
 OTEL_ENABLE=no

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
   - push
-  - pull_request
 
 jobs:
   lint:

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONFAULTHANDLER 1
+
+RUN apt-get update && \
+    apt-get upgrade -y
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir Flask gunicorn
+
+RUN adduser --disabled-password app
+USER app
+
+WORKDIR /mocked_integrations
+
+COPY --chown=app ./mocked_integrations mocked_integrations
+
+COPY --chown=app --chmod=775 ./entrypoint.sh ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/development/entrypoint.sh
+++ b/development/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+exec gunicorn \
+  --access-logfile - \
+  --bind '[::]:8000' \
+  --worker-tmp-dir /dev/shm \
+  --workers "${GUNICORN_WORKERS:-3}" \
+  mocked_integrations:app

--- a/development/mocked_integrations/__init__.py
+++ b/development/mocked_integrations/__init__.py
@@ -1,0 +1,41 @@
+from flask import Flask, jsonify, redirect, render_template, request
+
+app = Flask(__name__)
+
+state = {}
+
+
+@app.get("/")
+def index():
+    return render_template("index.html", state=state)
+
+
+@app.post("/add")
+def add():
+    user = request.form.get("id")
+    if user:
+        state[user] = True
+
+    return redirect("/")
+
+
+@app.get("/<user>/toggle")
+def toggle(user):
+    state[user] = not state.get(user, False)
+    return redirect("/")
+
+
+@app.get("/<user>/delete")
+def delete(user):
+    del state[user]
+    return redirect("/")
+
+
+@app.get("/discord/can-link")
+def can_link():
+    user = request.args.get("id")
+    if user is None:
+        return jsonify({"success": False, "reason": "invalid request"}), 422
+
+    status = state.setdefault(user, False)
+    return jsonify({"status": status})

--- a/development/mocked_integrations/templates/index.html
+++ b/development/mocked_integrations/templates/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mocked Integrations</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+</head>
+<body>
+  <div class="container">
+    <h1>Mocked Integrations</h1>
+
+    <br/><br/>
+
+    <form action="/add" method="post" class="row row-cols-lg-auto g-3 align-items-center">
+      <div class="col-12">
+        <label for="id">User ID</label>
+      </div>
+      <div class="col-12">
+        <input type="text" class="form-control" id="id" name="id" placeholder="google-oauth|123456">
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Add</button>
+      </div>
+    </form>
+
+    <br/><br/>
+
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">User ID</th>
+          <th scope="col">Can Link?</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user, status in state.items() %}
+          <tr>
+            <th scope="row">{{ user }}</th>
+            <td>
+              {% if status %}
+                Yes
+              {% else %}
+                No
+              {% endif %}
+            </td>
+            <td>
+              <a class="btn btn-sm btn-primary" href="/{{ user }}/toggle">Toggle</a>
+              <a class="btn btn-sm btn-danger" href="/{{ user }}/delete">Delete</a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/discord_linking/app.py
+++ b/discord_linking/app.py
@@ -4,7 +4,7 @@ from authlib.integrations.base_client.errors import MismatchingStateError
 from flask import Flask, g, redirect, render_template, request, session, url_for
 from opentelemetry import trace
 
-from . import auth0, database, dependencies, discord, internal, oauth, tracing
+from . import auth0, database, dependencies, discord, internal, nats, oauth, tracing
 from .database import User, db
 
 app = Flask(__name__)
@@ -12,6 +12,7 @@ app.config.from_object("discord_linking.settings")
 
 database.init(app)
 dependencies.init(app)
+nats.init(app)
 oauth.init(app)
 tracing.init(app, db)
 

--- a/discord_linking/app.py
+++ b/discord_linking/app.py
@@ -34,7 +34,7 @@ def require_login():
         return
 
     # Handle initial login
-    if session.get("auth0:login"):
+    if session.get("auth0:login") and request.path == url_for("auth0.callback"):
         del session["auth0:login"]
         return
     elif "id" not in session:
@@ -46,7 +46,7 @@ def require_login():
     trace.get_current_span().set_attribute("user.id", g.user.id)
 
     # Handle linking
-    if session.get("discord:login"):
+    if session.get("discord:login") and request.path == url_for("discord.callback"):
         del session["discord:login"]
         return
     elif request.path != url_for("discord.callback") and g.user.link is None:

--- a/discord_linking/app.py
+++ b/discord_linking/app.py
@@ -110,6 +110,7 @@ def logout():
 def unlink():
     with tracer.start_as_current_span("delete"):
         if g.user.link:
+            g.user.reset()
             db.session.delete(g.user.link)
             db.session.commit()
 

--- a/discord_linking/app.py
+++ b/discord_linking/app.py
@@ -90,6 +90,7 @@ def edit():
             db.session.commit()
 
         if g.user.agreed:
+            nats.publish("linked")
             return redirect(url_for("index"))
         else:
             return render_template(
@@ -110,6 +111,8 @@ def logout():
 def unlink():
     with tracer.start_as_current_span("delete"):
         if g.user.link:
+            nats.publish("unlinked")
+
             g.user.reset()
             db.session.delete(g.user.link)
             db.session.commit()

--- a/discord_linking/auth0.py
+++ b/discord_linking/auth0.py
@@ -80,7 +80,7 @@ def callback():
             pass
 
     session["id"] = user.id
-    return redirect(url_for("index"))
+    return redirect(url_for("edit"))
 
 
 def decode_jwt(raw):

--- a/discord_linking/database.py
+++ b/discord_linking/database.py
@@ -32,6 +32,10 @@ class User(db.Model):
     def can_link(self):
         return dependencies.can_link(self.id)
 
+    def reset(self):
+        self.agreed_to_rules = False
+        self.agreed_to_code_of_conduct = False
+
 
 class Link(db.Model):
     __tablename__ = "links"

--- a/discord_linking/discord.py
+++ b/discord_linking/discord.py
@@ -54,4 +54,4 @@ def callback():
         db.session.add(link)
         db.session.commit()
 
-    return redirect(url_for("index"))
+    return redirect(url_for("edit"))

--- a/discord_linking/nats.py
+++ b/discord_linking/nats.py
@@ -1,0 +1,72 @@
+import json
+
+from flask import current_app, g
+from nats import NATS
+from nats.js import JetStreamContext
+from nats.js.api import RetentionPolicy, StorageType
+from nats.js.errors import NotFoundError
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+STREAM_NAME = "discord-linking"
+
+__client = NATS()
+__propagator = TraceContextTextMapPropagator()
+
+
+def init(app):
+    create_stream(app)
+
+
+async def __connect(app=current_app) -> JetStreamContext:
+    """
+    Handle automatically connecting to NATS when needed
+    """
+    if not __client.is_connected and not __client.is_reconnecting:
+        await __client.connect(servers=[app.config.get("NATS_URL")])
+
+    return __client.jetstream()
+
+
+def create_stream(app=current_app):
+    """
+    Create a new stream if it doesn't already exist
+    """
+
+    async def inner():
+        jetstream = await __connect(app)
+
+        try:
+            await jetstream.stream_info(STREAM_NAME)
+        except NotFoundError:
+            await jetstream.add_stream(
+                name=STREAM_NAME,
+                subjects=[f"{STREAM_NAME}.*"],
+                description="for the Discord linking service",
+                storage=StorageType.FILE,
+                retention=RetentionPolicy.LIMITS,
+                num_replicas=1,
+                max_age=60 * 60 * 24 * 180,  # 6 months
+            )
+
+    app.ensure_sync(inner)()
+
+
+def publish(event: str):
+    """
+    Publish a message to a particular subject
+    """
+
+    async def inner():
+        jetstream = await __connect()
+
+        # Inject tracing
+        headers = {}
+        __propagator.inject(headers)
+
+        # Encode the body
+        body = {"id": g.user.id}
+        encoded = json.dumps(body).encode("utf-8")
+
+        await jetstream.publish(f"{STREAM_NAME}.{event}", encoded, headers=headers)
+
+    current_app.ensure_sync(inner)()

--- a/discord_linking/settings.py
+++ b/discord_linking/settings.py
@@ -45,3 +45,6 @@ APPLICATION_PORTAL_URL = environ.get(
     "APPLICATION_PORTAL_URL",
     "http://integrations.application-portal.wafflemaker.internal:8000",
 )
+
+# The NATS JetStream server to connect to
+NATS_URL = environ.get("NATS_URL", "nats://127.0.0.1:3542")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,15 @@ services:
     ports:
       - "3579:6379"
 
+  nats:
+    image: nats:2.8.4-scratch
+    command:
+      - -a=0.0.0.0
+      - -p=4222
+      - --jetstream
+    ports:
+      - "3542:4222"
+
   jaeger:
     image: jaegertracing/all-in-one:1.34
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,14 @@ services:
     ports:
       - "3542:4222"
 
+  integrations:
+    image: discord-linking/mocked-integrations:dev
+    build:
+      context: ./development
+      dockerfile: Dockerfile
+    ports:
+      - "3580:8000"
+
   jaeger:
     image: jaegertracing/all-in-one:1.34
     ports:

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,6 +22,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "asgiref"
+version = "3.5.2"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+
+[[package]]
 name = "asttokens"
 version = "2.0.5"
 description = "Annotate AST trees with source code positions"
@@ -254,6 +265,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+asgiref = {version = ">=3.2", optional = true, markers = "extra == \"async\""}
 click = ">=8.0"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.0"
@@ -528,6 +540,17 @@ description = "Experimental type system extensions for programs checked with the
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "nats-py"
+version = "2.1.3"
+description = "NATS client for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+nkeys = ["nkeys"]
 
 [[package]]
 name = "nodeenv"
@@ -1203,7 +1226,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "fc6bfd2407af10b21f5e9116fcab7e82d8c33e21d9db3bd0f59fef3160366484"
+content-hash = "a90fc86d9cb78afd788acbab57dec88b8fa50e62840c551d0a37743a9318a19b"
 
 [metadata.files]
 alembic = [
@@ -1213,6 +1236,10 @@ alembic = [
 appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
+]
+asgiref = [
+    {file = "asgiref-3.5.2-py3-none-any.whl", hash = "sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4"},
+    {file = "asgiref-3.5.2.tar.gz", hash = "sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424"},
 ]
 asttokens = [
     {file = "asttokens-2.0.5-py2.py3-none-any.whl", hash = "sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c"},
@@ -1609,6 +1636,9 @@ matplotlib-inline = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+nats-py = [
+    {file = "nats-py-2.1.3.tar.gz", hash = "sha256:b570256ac968f1d7d0749536a0baa1db79ee268e0a6fb2cee67d304ab6a62fae"},
 ]
 nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "discord_linking"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-Flask = "^2.1.2"
+Flask = { version = "^2.1.2", extras = ["async"] }
 python-dotenv = "^0.20.0"
 Flask-SQLAlchemy = "^2.5.1"
 Flask-Migrate = "^3.1.0"
@@ -31,6 +31,7 @@ opentelemetry-instrumentation-sqlalchemy = "0.30b1"
 opentelemetry-instrumentation-botocore = "0.30b1"
 opentelemetry-instrumentation-jinja2 = "0.30b1"
 opentelemetry-instrumentation-redis = "0.30b1"
+nats-py = "^2.1.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
Whenever a participant links or unlinks their Discord account, events will be broadcast to the `discord-linking.linked` and `discord-linking.unlinked` subjects respectively. This allows other services, namely WaffleBot, to get real-time updates on whether a participant has applied and was accepted.

In addition, a mocked version of the application portal integrations service was added to make development easier. It exposes a web interface allowing developers to add and remove user IDs and change whether their associated profile is linkable.